### PR TITLE
テスト、SentMessageエンティティのMESSAGE_IDの長さを拡張。

### DIFF
--- a/src/test/java/nablarch/fw/messaging/action/SentMessage.java
+++ b/src/test/java/nablarch/fw/messaging/action/SentMessage.java
@@ -24,7 +24,7 @@ public class SentMessage {
     }
 
     @Id
-    @Column(name = "MESSAGE_ID", length = 64,  nullable = false)
+    @Column(name = "MESSAGE_ID", length = 255,  nullable = false)
     public String messageId;
 
     @Column(name = "REQUEST_ID", length = 64,  nullable = false)

--- a/src/test/java/nablarch/fw/messaging/handler/SentMessage.java
+++ b/src/test/java/nablarch/fw/messaging/handler/SentMessage.java
@@ -25,7 +25,7 @@ public class SentMessage {
 	}
 
 	@Id
-    @Column(name = "MESSAGE_ID", length = 64, nullable = false)
+    @Column(name = "MESSAGE_ID", length = 255, nullable = false)
     public String messageId;
 
 	@Id

--- a/src/test/java/nablarch/fw/messaging/sample/SampleSentMessage.java
+++ b/src/test/java/nablarch/fw/messaging/sample/SampleSentMessage.java
@@ -25,7 +25,7 @@ public class SampleSentMessage {
 	}
 
 	@Id
-    @Column(name = "MESSAGE_ID", length = 64, nullable = false)
+    @Column(name = "MESSAGE_ID", length = 255, nullable = false)
     public String messageId;
     
 	@Id


### PR DESCRIPTION
ActiveMQが環境情報からlocalhostの値を設定するため、その環境依存に対するテスト実行の安定化処置として実施。