### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/fw/messaging/FwHeaderDefinition.java
+++ b/src/main/java/nablarch/fw/messaging/FwHeaderDefinition.java
@@ -1,11 +1,14 @@
 package nablarch.fw.messaging;
 
+import nablarch.core.util.annotation.Published;
+
 /**
  * 送受信電文中のフレームワーク制御ヘッダ項目に対する読み書きを行うモジュールが
  * 実装するインターフェース。
  * 具体的に電文中のどの部分をフレームワーク制御ヘッダの各項目に対応させるかについては、
  * 各具象クラスごとに異なる。
  */
+@Published(tag = "architect")
 public interface FwHeaderDefinition {
     /**
      * 受信電文中のフレームワーク制御ヘッダ部を読み込み、

--- a/src/main/java/nablarch/fw/messaging/action/MessagingAction.java
+++ b/src/main/java/nablarch/fw/messaging/action/MessagingAction.java
@@ -9,7 +9,6 @@ import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
 import nablarch.fw.TransactionEventCallback;
-import nablarch.fw.messaging.ReceivedMessage;
 import nablarch.fw.messaging.RequestMessage;
 import nablarch.fw.messaging.ResponseMessage;
 


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/system_messaging/http_system_messaging.html#http-system-messaging-change-fw-header)には`FwHeaderDefinition`の実装例が記載されているにもかかわらず、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。